### PR TITLE
Add schedule and links for the 2020 conference

### DIFF
--- a/docs/2020.md
+++ b/docs/2020.md
@@ -9,6 +9,39 @@ Partners: Cisco, Equinor, Kongsberg, ProgramUtvikling
 
 This was the agenda of 2020:
 
-__Thursday 1020-1120:__
+__Thursday 0900-1000: (Plenary)__
+
+- Keynote: Kate Gregory
+
+__Thursday 1020-1120: (Parallel sessions)__
 
 - Trying to build an Open Source browser in 2020, Patricia Aas ([YouTube](https://youtu.be/eYKM_wJNzUY), [Slides](https://www.slideshare.net/PatriciaAas/trying-to-build-an-open-source-browser-in-2020))
+- What do you mean by "Cache Friendly?", Björn Fahller ([YouTube](https://youtu.be/jrfZDtDgKYk))
+- Coroutines are Qt: safer thread pools interactions, Fezzardi Carlucci ([YouTube](https://youtu.be/tbrZGXtdnYE))
+- Battles of an Impostor, Melissa Houghton ([YouTube](https://youtu.be/wEPYczHSf-w))
+
+__Thursday 1140-1220: (Parallel sessions)__
+
+- 25 Years of SSL - Secure(ish) Socket Layer, Scott Helme ([YouTube](https://youtu.be/7TOakcl5ANQ))
+- Leadership Guide for the Reluctant Leader, David Neal, ([YouTube](https://youtu.be/mSkVkPG0m80))
+- Lazy QObject tree traversal, Vitaly Fanaskov ([YouTube](https://youtu.be/hqo6bdnwPH8))
+- Algorithmic and microarchitecture optimizations of C++ applications, Alexander Maslennikov ([YouTube](https://youtu.be/OAQy7ysp93I))
+
+__Thursday 1340-1440: (Parallel sessions)__
+
+- Embracing Simplicity, Guilherme Ferreira ([YouTube](https://youtu.be/pLMKbNQdSoI))
+- QProperty - QML property binding in C++, Mikhail Svetkin ([YouTube](https://youtu.be/28wu6sXnTBs))
+- C++ ecosystem: the renaissance edition, Anastasiia Kazakova ([YouTube](https://youtu.be/5G3EtDwW4Xs))
+
+__Thursday 1500-1600: (Parallel sessions)__
+
+- The Pipes Library: How Plumbing Can Make Your Code More Expressive, Jonathan Boccara ([YouTube](https://youtu.be/gWxBonPkrGM))
+- You've Been Coded Out, Lia James
+- Proactive Security, less buzzword, more action, Siren Hofvander ([YouTube](https://youtu.be/Gpfr4RvRdfk))
+- C++ Error Handling Revisited, Raphael Meyer ([YouTube](https://youtu.be/Ybmomkc48wg))
+
+__Thursday 1620-1720: (Parallel sessions)__
+
+- How not to choke on a big old project, Yuri Minaev ([YouTube](https://youtu.be/6sv7jtWKU1A))
+- Paradigms Lost, Paradigms Regained: Programming with Objects and Functions and More, Kevlin Henney ([YouTube](https://youtu.be/0CJMN_kvL5Q))
+- C++ Parallel Programming Models, Eran Gilad ([YouTube](https://youtu.be/2T97nULFVb0))


### PR DESCRIPTION
We are missing the keynote from Kate. I don't remember the title, and we did have issues with the recording, so there is no recording of it.