### PR TITLE
Normalize speaker name

### DIFF
--- a/docs/2023.md
+++ b/docs/2023.md
@@ -66,7 +66,7 @@ __Wednesday 1730-2200: (Keynote, Quiz, Party)__
 
 - NDC Party
 - 1740-1840 Keynote: Steps to Wisdom, Kate Gregory ([YouTube](https://www.youtube.com/watch?v=iS9mbqho6s0&list=PL03Lrmd9CiGdBvVUXpZCKK88-Vpd5VwEo))
-- 2000-2100 C++ Quiz with Anders Knatten
+- 2000-2100 C++ Quiz with Anders Schau Knatten
 
 __Thursday 0900-1000: (Parallel sessions)__
 

--- a/docs/2024.md
+++ b/docs/2024.md
@@ -22,7 +22,7 @@ __Pre-conf workshops (Monday and Tuesday):__
 
 __Pre-conf meetup (Tuesday evening 1800-2000)__
 
-- C++ Brain Teasers Book Launch with Anders Knatten and Olve Maudal ([video](https://www.youtube.com/live/Eb3h3JDEs0Q), [book](https://pragprog.com/titles/akbrain/c-brain-teasers/))
+- C++ Brain Teasers Book Launch with Anders Schau Knatten and Olve Maudal ([video](https://www.youtube.com/live/Eb3h3JDEs0Q), [book](https://pragprog.com/titles/akbrain/c-brain-teasers/))
 
 __Wednesday 0900-1000: (Plenary)__
 


### PR DESCRIPTION
I was listed both as "Anders Knatten" and "Anders Schau Knatten", and prefer using the full name.